### PR TITLE
Added new option for providing updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,25 @@ function replaceAttr(token, attrName, replace, env) {
     });
 }
 
-module.exports = function (md) {
+module.exports = function (md, opts) {
     md.core.ruler.after(
         'inline',
         'replace-link',
         function (state) {
-            var replace = md.options.replaceLink;
+            var replace = null;
+
+            // Use markdown options (default so far)
+            if (md.options.replaceLink && typeof md.options.replaceLink === 'function') {
+                replace = md.options.replaceLink;
+            }
+            // Alternatively use plugin options provided upon .use(..)
+            else if (opts && opts.replaceLink && typeof opts.replaceLink === 'function') {
+                replace = opts.replaceLink;
+            }
+            else {
+                return false;
+            }
+
             if (typeof replace === 'function') {
                 state.tokens.forEach(function (blockToken) {
                     if (blockToken.type === 'inline' && blockToken.children) {
@@ -24,9 +37,9 @@ module.exports = function (md) {
                             } else if (type === 'image') {
                                 replaceAttr(token, 'src', replace, state.env);
                             }
-                        }); 
+                        });
                     }
-                }); 
+                });
             }
             return false;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -30,3 +30,30 @@ describe('markdown-it-replace-link', function() {
     done();
   });
 });
+
+describe('markdown-it-replace-link w. plugin options', function () {
+  var md = require('markdown-it')({
+    html: true,
+    linkify: true,
+    typography: true
+  }).use(require('../'), {
+    replaceLink: function (link, env, token) {
+      if (token.type === 'image') {
+        return 'image/' + link
+      }
+      if (link === 'a') {
+        return env.x + link;
+      }
+      return "http://me.com/" + link;
+    }
+  });
+  generate(path.join(__dirname, 'fixtures/toc.txt'), md);
+
+  it("Passes on env", function (done) {
+    var html = md.render(fs.readFileSync(path.join(__dirname, 'fixtures/env.txt'), 'utf-8'), {
+      x: 'test/'
+    })
+    expect(html).to.equal("<p><a href=\"test/a\">Hello</a></p>\n");
+    done();
+  });
+});


### PR DESCRIPTION
Added an alternative option that most plugins have..

Which is providing the replaceLink function upon USE(..)
```
var md = require('markdown-it')().use(markdown-it-replace-link,
{
    replaceLink: function (link, env, token) { ... }
});
```