### PR TITLE
Fix TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,15 +4,15 @@ import type { Token } from 'markdown-it';
 import type { ChildNode } from 'domhandler';
 
 export interface ReplaceLinkOptions {
-  replaceLink(
+  replaceLink?(
     link: string,
     env: { [key: string]: unknown },
     token: Token,
     node: ChildNode
   ): string;
-  processHTML: boolean;
+  processHTML?: boolean;
 }
 
-function markdownItReplaceLink(md: MarkdownIt, opts: ReplaceLinkOptions): void;
+function markdownItReplaceLink(md: MarkdownIt, opts?: ReplaceLinkOptions): void;
 
-exports = markdownItReplaceLink;
+export = markdownItReplaceLink;


### PR DESCRIPTION
Hi @martinheidegger,

Thank you very much for this project!

After upgrading my project to TypeScript, I got the following error with `markdown-it-replace-link`:

> error TS2322: Type 'typeof import(".../node_modules/markdown-it-replace-link/index")' is not assignable to type 'PluginWithOptions'.

I fixed this error by replacing `exports =` with `export =` and making the `opt` argument optional.

In addition, I changed the definition of `ReplaceLinkOptions` to make both `replaceLink` and `processHTML` in accordance with the JavaScript source.

@michaelhthomas, please let me know if this looks good to you.

Best regards,



